### PR TITLE
ログインユーザーが登録したカテゴリーだけ表示されるよう修正しました

### DIFF
--- a/src/public/category/edit.php
+++ b/src/public/category/edit.php
@@ -69,6 +69,6 @@ $category = $statement->fetch(PDO::FETCH_ASSOC);
             'name'
         ]; ?>"></p>
         <button type="submit">更新</button>
-        <a href="./index.php?id=">戻る</a>
+        <a href="./index.php">戻る</a>
     </form>
 </body>

--- a/src/public/category/index.php
+++ b/src/public/category/index.php
@@ -14,10 +14,17 @@ unset($_SESSION['errors']);
 $userId = $_SESSION['id'];
 $name = filter_input(INPUT_POST, 'name');
 
-$sql = 'SELECT * FROM categories';
+$sql = 'SELECT * FROM categories WHERE user_id = :userId'; // ログインユーザーのカテゴリーのみを取得するクエリ
 $statement = $pdo->prepare($sql);
+$statement->bindValue(':userId', $userId, PDO::PARAM_INT);
 $statement->execute();
 $categories = $statement->fetchAll(PDO::FETCH_ASSOC);
+$categoriesInfoList = [];
+foreach ($categoriesInfoList as $categoriesInfo) {
+    if ($_SESSION['id'] == $categoriesInfo['user_id']) {
+        $categories[] = $categoriesInfo;
+    }
+}
 ?>
 
 <!DOCTYPE html>

--- a/src/public/category/update.php
+++ b/src/public/category/update.php
@@ -21,7 +21,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (empty($categoryName)) {
         session_start();
         $_SESSION['errors'][] = 'カテゴリー名を入力してください。';
-        header('Location: ./edit.php?id=' . $categoryId);
+        header('Location: ./index.php?id=' . $categoryId);
         exit();
     } else {
         $sql =


### PR DESCRIPTION
### 作業した教材のURL

[https://www.notion.so/9cf9452e2a504c6db89375c3f8a825c0?pvs=4](url)

### 作成したページのURL

[http://localhost:8080/category/index.php](url)  カテゴリー一覧ページ
[http://localhost:8080/category/store.php?id=](url)  カテゴリー一覧機能
[http://localhost:8080/category/edit.php?id=](url)　カテゴリー名編集ページ
[http://localhost:8080/category/update.php?id=](url)　カテゴリー名編集機能
[http://localhost:8080/category/delete.php?id=](url)　カテゴリー削除機能

### 作業詳細
カテゴリー一覧を登録したユーザーのものだけ表示

### 解決方法
①レビューして頂いたコードで修正

②$categoriesInfoListが定義されていないエラーがでる

③blogアプリを見直して$categoriesInfoList = [];で修正

④エラーは消えたが他ユーザーのものも表示されてしまう

⑤chatgptで調べた結果ログインユーザーのカテゴリーのみを取得するクエリが抜けていたことが分かったため17行目を追加しログインユーザーのみカテゴリー一覧を表示成功(*'▽')


![index php - create-todo  WSL_ Ubuntu  - Visual Studio Code 2023_06_21 0_22_26 (2)](https://github.com/AsukaKanematsu/create-todo/assets/129743465/52ef6490-d20a-4637-9a87-3fb8cdffb833)



https://github.com/AsukaKanematsu/create-todo/assets/129743465/760c6403-e78c-49fc-a017-858f660378d3


