### PR TITLE
更新ボタンを押したらcategory/index.phpに遷移しエラー文を表示させるように修正

### DIFF
--- a/src/public/category/edit.php
+++ b/src/public/category/edit.php
@@ -69,6 +69,6 @@ $category = $statement->fetch(PDO::FETCH_ASSOC);
             'name'
         ]; ?>"></p>
         <button type="submit">更新</button>
-        <a href="./index.php?id=">戻る</a>
+        <a href="./index.php">戻る</a>
     </form>
 </body>

--- a/src/public/category/update.php
+++ b/src/public/category/update.php
@@ -21,7 +21,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (empty($categoryName)) {
         session_start();
         $_SESSION['errors'][] = 'カテゴリー名を入力してください。';
-        header('Location: ./edit.php?id=' . $categoryId);
+        header('Location: ./index.php?id=' . $categoryId);
         exit();
     } else {
         $sql =


### PR DESCRIPTION
### 作業した教材のURL

[https://www.notion.so/9cf9452e2a504c6db89375c3f8a825c0?pvs=4](url)

### 作成したページのURL

[http://localhost:8080/category/index.php?id=](url)  カテゴリー一覧ページ
[http://localhost:8080/category/store.php?id=](url)  カテゴリー一覧機能
[http://localhost:8080/category/edit.php?id=](url)　### カテゴリー名編集ページ
[http://localhost:8080/category/update.php?id=](url)　カテゴリー名編集機能
[http://localhost:8080/category/delete.php?id=](url)　カテゴリー削除機能

### 解決方法
**category/update.php**の24行目の遷移先が**edit.php**になっていたのでindex.php?=idに変更しました
chatgptなど検索ツールを使わず解決できました(^^♪

### 疑問点
**category/update.php**の24行目**’Location: ./index.php’**で更新ボタンを押したらpublic/index.phpにとんでしまいました。
**?=id**が必要な場合必要ではない場合の違いが難しく感じました。

![Pull Request #4 - create-todo  WSL_ Ubuntu  - Visual Studio Code 2023_06_21 1_09_50 (2)](https://github.com/AsukaKanematsu/create-todo/assets/129743465/ac721a9b-b9cb-4bd7-944b-6fd9fb866cac)

### 作業詳細
更新ボタンを押したらcategory/index.phpに遷移しエラー文を表示させるように修正しました。



https://github.com/AsukaKanematsu/create-todo/assets/129743465/8fbf67fa-f274-4e2b-af54-d118a2c83124



